### PR TITLE
Google maps controls

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -183,6 +183,9 @@ jQuery(function($) {'use strict';
 			center: myLatlng
 		};
 		var map = new google.maps.Map(document.getElementById('google-map'), mapOptions);
+		map.addListener('bounds_changed', function () {
+			map.setCenter(myLatlng);
+		});
 		var marker = new google.maps.Marker({
 			position: myLatlng,
 			map: map

--- a/js/main.js
+++ b/js/main.js
@@ -177,6 +177,9 @@ jQuery(function($) {'use strict';
 		var mapOptions = {
 			zoom: 14,
 			scrollwheel: false,
+			zoomControl: false,
+			streetViewControl: false,
+			mapTypeControl: false,
 			center: myLatlng
 		};
 		var map = new google.maps.Map(document.getElementById('google-map'), mapOptions);


### PR DESCRIPTION
usunięcie zbędnych (nieosiągalnych i tak) kontrolek z mapy google na dole + sprawienie żeby mapa była zawsze wycentrowana na markerze (nawet po resize okna)
