### PR TITLE
poprawione literówki

### DIFF
--- a/index.html
+++ b/index.html
@@ -519,7 +519,7 @@
                 <h2 class="section-title text-center wow fadeInDown">Kariera</h2>
                 <p class="text-center wow fadeInDown">
                     IHS jest dynamicznie rozwijającą się firmą. Współpracujemy z doświadczonymi specjalistami, jak również ze studentami dopiero zaczynającymi swoją karierę.<br />
-                    Poszukujemy ludzi z pasają, talentem, którzy chcą rozwijać swoją wiedzę i umiejętności. Aktualnie rekrutujemy na stanowiska:
+                    Poszukujemy ludzi z pasją, talentem, którzy chcą rozwijać swoją wiedzę i umiejętności. Aktualnie rekrutujemy na stanowiska:
                 </p>
             </div>
 
@@ -529,7 +529,7 @@
                     <h3 class="column-title">Senior Software Engineer</h3>
                 </div>
                 <div class="col-sm-9 wow fadeInRight">
-                    <h4><i class="fa fa-graduation-cap"></i>To czego od ciebie oczekujemy to:</h4>
+                    <h4><i class="fa fa-graduation-cap"></i>To czego od Ciebie oczekujemy to:</h4>
                     <p>
                         Doświadczony programista, który jest w stanie tak samodzielnie, jak i w większej grupie implementować wymagania, które uprzednio zanalizował i zaakceptował dbając o&nbsp;maksymalizację wartości dla użytkowników przy minimalizacji kosztów
                         i prostotę utrzymania oprogramowania.
@@ -557,7 +557,7 @@
                     <h3 class="column-title">Software Engineer</h3>
                 </div>
                 <div class="col-sm-9 wow fadeInRight">
-                    <h4><i class="fa fa-graduation-cap"></i>To czego od ciebie oczekujemy to:</h4>
+                    <h4><i class="fa fa-graduation-cap"></i>To czego od Ciebie oczekujemy to:</h4>
                     <ul>
                         <li>bardzo dobra znajomosc platformy .Net i języka C#,</li>
                         <li>posługiwanie się w sposób komunikatywny językiem angielskim,</li>
@@ -580,7 +580,7 @@
                     <h3 class="column-title">Software Quality Assurance Engineer</h3>
                 </div>
                 <div class="col-sm-9 wow fadeInRight">
-                    <h4><i class="fa fa-graduation-cap"></i>To czego od ciebie oczekujemy to:</h4>
+                    <h4><i class="fa fa-graduation-cap"></i>To czego od Ciebie oczekujemy to:</h4>
                     <ul>
                         <li>umiejetność monitorowania, wyszukiwania i obsługi błędów systemów informatycznych,</li>
                         <li>doświadczenie w opracowywaniu dokumentacji oraz scenariuszy testowych uwzględniających przewidywane &#8222;ścieżki krytyczne&#8221,</li>
@@ -625,7 +625,7 @@
         <div class="container">
             <div class="col-sm-12 wow fadeInDown">
                 <p>Spodobała Ci się nasza firma i chciałbyś do nas dołączyć? Napisz!<br/>
-                Nawet jeśli aktualnie nie mamy interesującej Cię propozycji, napisz do nas a prawdopodobnie znajdziemy coś dla ciebie<br /></p>
+                Nawet jeśli aktualnie nie mamy interesującej Cię propozycji, napisz do nas a prawdopodobnie znajdziemy coś dla Ciebie.<br /></p>
                 <a href="mailto:praca@ihs.com" class=" btn btn-primary btn-lg">Napisz do nas!</a>
             </div>
         </div>
@@ -727,7 +727,7 @@
             <div class="item">
                 <img src="images/ciekawostki/7.jpg" class="img-responsive" alt="Responsive image">
                 <h3>Akademia Messera</h3>
-                    <p>Pomysłodawcą Akademii był Maciek Kołosiński aka. Messer. Spotkania mają formę luźnej prezentacji i odbywają się średnio raz w miesiącu. Skupiamy się na tematach, na które zazwyczaj nie mamy czasu w pracy, a które nas interesują, a&nbsp;także też na nowinkach, które wdrażamy, Na zachętę, dla wszystkich pizza &nbsp; tak, aby nakarmić nie tylko umysł.</p>
+                    <p>Pomysłodawcą Akademii był Maciek Kołosiński aka. Messer. Spotkania mają formę luźnej prezentacji i odbywają się średnio raz w miesiącu. Skupiamy się na tematach, na które zazwyczaj nie mamy czasu w pracy, a które nas interesują, a&nbsp;także też na nowinkach, które wdrażamy. Na zachętę, dla wszystkich pizza&nbsp;tak, aby nakarmić nie tylko umysł.</p>
             </div>
 
             <div class="item">
@@ -856,7 +856,7 @@
                                             <h4 class="media-heading">Jak szlifujemy umiejętności?</h4>
                                             <p>
                                                 Subskrypcja MSDN, Pluralsight, coding dojos, własna biblioteczka papierowych książek, Akademia Messera &mdash; koledzy prezentują nowości gdy, Ty zajadasz się pizzą, wiedza kolegów, IHS Tech Conf &mdash; wewnętrzna konferencja techniczna,
-                                                wyjazdy na konferencje: DevDay, Lambda Days, BuildStuffLT, OreDev, NDC, WWDC, Warsztaty w Skills Matter, DevDay, ThoughtWorks, IHS Tech Conf - wewnętrzna konferencja ze znanymi prezenterami z Polski i zagranicy.
+                                                wyjazdy na konferencje: DevDay, Lambda Days, BuildStuffLT, OreDev, NDC, WWDC, Warsztaty w Skills Matter, ThoughtWorks, IHS Tech Conf - wewnętrzna konferencja ze znanymi prezenterami z Polski i zagranicy.
                                             </p>
                                         </div>
                                     </div>
@@ -967,7 +967,7 @@
             <div class="section-header">
                 <h2 class="section-title text-center wow fadeInDown animated" style="visibility: visible; animation-name: fadeInDown;">Kontakt</h2>
                 <p class="text-center wow fadeInDown animated" style="visibility: visible; animation-name: fadeInDown;">
-                    Zainteresowała cię nasza firma, nasze projekty czy może my sami?
+                    Zainteresowała Cię nasza firma, nasze projekty czy może my sami?
                     <br>Łap informację jak do nas trafić i postaraj się nas odwiedzić!
                 </p>
             </div>
@@ -1047,7 +1047,7 @@
                     <p>
                         W 2008 dynamicznie rozwijający się GlobalInsight przykuł uwagę amerykańskiego giganta informacyjnego IHS, który chciał poszerzyć swoją ofertę analizych i danych ekonomicznych. GlobalInsight został kupiony przez IHS, a gdańskie biuro zmieniło nazwę na
                         IHS&nbsp;Global. Dynamika rozwoju firmy jeszcze wzrosła, do firmy dołączyło wiele nowych osób, powstał specjalny dział Data Operations zajmujący się gromadzeniem i analizą danych ekonomicznych. Oprócz rozwijania projektów znanych
-                        z czasów GlobalInsight, IHS zaincjował wiele nowych krytycznych projektów, za których wykonanie odpowiada obecnie biuro w Gdańsku. Nowe projekty to Connect, "cos auto", Phoenix, Forecasting Tool, Timeseries Data Platform, Titan.
+                        z czasów GlobalInsight, IHS zaincjował wiele nowych krytycznych projektów, za których wykonanie odpowiada obecnie biuro w Gdańsku. Nowe projekty to Connect, Phoenix, Forecasting Tool, AutoForecast, Timeseries Data Platform, Titan.
                     </p>
 
                     <p>
@@ -1132,7 +1132,7 @@
                 </div>
                 <div class="modal-body">
                     <p>
-                        MyInsight jest przeznaczonym dla zewnętrznych klientów firmy systemem umożliwiającym dostęp do informacji i analiz sprzedawanych przez IHS w ramach subskrypcji. Zawiera setki tysięcy artykułów z takich dziedziń jak rolnictwo, przemysł
+                        MyInsight jest przeznaczonym dla zewnętrznych klientów firmy systemem umożliwiającym dostęp do informacji i analiz sprzedawanych przez IHS w ramach subskrypcji. Zawiera setki tysięcy artykułów z takich dziedzin jak rolnictwo, przemysł
                         samochodowy, bankowość, rynek energetyczny, biochemia i in. Oprócz tego jest to punkt wejścia do kilku aplikacji IHS, takich jak IHS AutoInsight, IHS SupplierBusines, IHS Hybrid-EV, IHS Automotive Technology czy DataInsight-Web.
                         System liczy 14 lat i nie jest obecnie rozwijany, a jego funkcjonalność oraz treść jest przenoszona do dwóch innych systemów: Phoenix i Connect.
                     </p>
@@ -1201,7 +1201,7 @@
                 <div class="modal-body">
                     <p>Nowoczesna platforma zarządzania seriami danych oparta o bazę NoSQL.</p>
                     <p>
-                        Timeseries Data Platform (TDP) to dynamicznie rozwijający się projekt, którego celem jest stworzenie systemu, który umożliwia zbieranie, przetwarzanie oraz publikowanie serii danych. Platforma jest zdolna przechowowywać dzieisiątki
+                        Timeseries Data Platform (TDP) to dynamicznie rozwijający się projekt, którego celem jest stworzenie systemu, który umożliwia zbieranie, przetwarzanie oraz publikowanie serii danych. Platforma jest zdolna przechowywać dziesiątki
                         milionow serii danych o różnych częstotliwościach. Jednocześnie jest w stanie przetwarzać operacje na milionach serii każdego dnia oraz dostarcza najbardziej zaawansowane usługi wyszukiwania informacji. W projekcie wykorzystywane
                         są takie technologie jak bazy NoSQL (MarkLogic, Redis), IBM MQ, Web Services.
                     </p>
@@ -1224,7 +1224,7 @@
                 </div>
                 <div class="modal-body">
                     <p>
-                        IHS Economic Simulation Engine to system poprzez który klienci IHS mogą zapoznać się z prognozami makroekonomicznymi zbudowanymi w oparciu o matematyczne modele stworzone przez analityków IHS. System umożliwia testowanie różnych scenariuszy
+                        IHS Economic Simulation Engine to system, poprzez który klienci IHS mogą zapoznać się z prognozami makroekonomicznymi zbudowanymi w oparciu o matematyczne modele stworzone przez analityków IHS. System umożliwia testowanie różnych scenariuszy
                         w oparciu o modele IHS oraz własne założenia co do zjawisk zachodzących w przyszłości. Rozwiązanie oparte jest na systemie EViews, który jest popularnym narzędziem analityków pracujących z modelami ekonometryczymi. W platformie
                         wykorzystano takie technologie jak WCF, WPF, Infragistics.
                     </p>
@@ -1504,10 +1504,6 @@
                     </p>
                     <p class="text-center">
                         <img src="images/articles/2015.10/hack_swift/programisci.jpg" class="img img-responsive img-thumbnail" alt="HackSwift image 0" />
-                    </p>
-                    <p>
-                        Zasady były proste: sześć godzin, sześć par i jedna z dwóch gwiezdno-wojennych gier do stworzenia: Memory Lorda Vadera lub Bitwa X-Winga z Tie-Fighterem. Dodatkowo co dwadzieścia minut wybrzmiewał dzwonek, który sygnalizował zmianę operatora
-                        klawiatury. Zabawa była przednia, co chwilę słychać było laserowe strzały, narzekania na konstrukcje języka albo radość z kompilującego się kodu, a do tego wszystkiego przygrywał nam Cantina Band.
                     </p>
                     <p>
                         Po sześciu godzinach każdy z zespołów miał przynajmniej namiastkę gry którą wybrał, a część z nich wyglądała jakby była gotowa do wysłania na AppStore-a. Dzięki wszystkim za świetną zabawę i do zobaczenia na kolejnym hackatonie! Niech


### PR DESCRIPTION
1. podmieniłem "cos auto" na AutoForecast - jedyny chyba aktywnie rozwijany projekt auto w Gdańsku
2. w opisie Hackatonu był powtórzony cały akapit, nie wiedziałem czy ma zostać ten przed zdjęciem czy ten poniżej zdjęcia - zostawiłem pierwszy
