### PR TITLE
center the map on the marker every time map bounds change

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -234,6 +234,9 @@ jQuery(function($) {'use strict';
 			center: myLatlng
 		};
 		var map = new google.maps.Map(document.getElementById('google-map'), mapOptions);
+		map.addListener('bounds_changed', function () {
+			map.setCenter(myLatlng);
+		});
 		var marker = new google.maps.Marker({
 			position: myLatlng,
 			map: map


### PR DESCRIPTION
this is to ensure the map is always centered on the marker location, even when someone resizes the window

more info on event handlers can be found here:
https://developers.google.com/maps/documentation/javascript/events
