### PR TITLE
Fix: Tools section content tweaks

### DIFF
--- a/index.html
+++ b/index.html
@@ -1121,19 +1121,9 @@
                                             <i class="fa fa-circle"></i>
                                         </div>
                                         <div class="media-body">
-                                            <h4 class="media-heading">Jak wersjonujemy kod?</h4>
-                                            <p>GIT, TFS.</p>
-                                        </div>
-                                    </div>
-
-                                    <div class="media service-box-nohover">
-                                        <div class="pull-left">
-                                            <i class="fa fa-circle"></i>
-                                        </div>
-                                        <div class="media-body">
                                             <h4 class="media-heading">W czym piszemy?</h4>
                                             <p>
-                                                Visual Studio + Resharper, IntelliJ IDEA, XCode, AppCode, Android Studio.
+                                                Visual Studio + Resharper, Visual Studio Code, JetBrains Rider, IntelliJ IDEA, XCode, AppCode, Android Studio.
                                             </p>
                                         </div>
                                     </div>
@@ -1145,8 +1135,12 @@
                                         <div class="media-body">
                                             <h4 class="media-heading">Jak szlifujemy umiejętności?</h4>
                                             <p>
-                                                Subskrypcja MSDN, Pluralsight, coding dojos, własna biblioteczka papierowych książek, Akademia Messera &mdash; koledzy prezentują nowości gdy, Ty zajadasz się pizzą, wiedza kolegów, IHS Tech Conf &mdash; wewnętrzna konferencja techniczna,
-                                                wyjazdy na konferencje: DevDay, Lambda Days, BuildStuffLT, OreDev, NDC, WWDC, Warsztaty w Skills Matter, ThoughtWorks, IHS Tech Conf - wewnętrzna konferencja ze znanymi prezenterami z Polski i zagranicy.
+                                                <ul>
+                                                    <li>Pluralsight, subskrypcja MSDN, Coding Dojos, firmowa biblioteczka,</li>
+                                                    <li>Akademia Messera &mdash; koledzy prezentują nowości gdy Ty zajadasz się pizzą,</li> 
+                                                    <li>fundowane wyjazdy na zagraniczne konferencje,</li> 
+                                                    <li>IHS Tech Conf - wewnętrzna konferencja ze znanymi prezenterami z Polski i zagranicy.</li> 
+                                                </ul>
                                             </p>
                                         </div>
                                     </div>
@@ -1167,7 +1161,7 @@
                                         </div>
                                         <div class="media-body">
                                             <h4 class="media-heading">Czym jeszcze się wspieramy?</h4>
-                                            <p>TeamCity, Pakiety Infragistics, Confluence, Bitbucket, Atlassian Stash.</p>
+                                            <p>TeamCity, Infragistics, Confluence, Bitbucket.</p>
                                         </div>
                                     </div>
 
@@ -1178,7 +1172,7 @@
                                         <div class="media-body">
                                             <h4 class="media-heading">Czego jeszcze się nauczysz pracując u nas?</h4>
                                             <p>
-                                                Bootstrap, NServiceBus, Dapper, WPF, Angular, NodeJS, Jasmine, Selenium, Genymotion, HighCharts, Reveal, Charles, TypeScript, Ruby, Entity Framework, NHibernate, Machine Specifications, Property-Based Testing, MSDeploy, JSLint,
+                                                Bootstrap, NServiceBus, WPF, Angular, NodeJS, Genymotion, HighCharts, TypeScript, Entity Framework / NHibernate / Dapper.NET, Machine Specifications, Property-Based Testing, Jasmine, Selenium, ESLint / TSLint,
                                                 Castle Windsor, FsCheck
                                             </p>
                                         </div>
@@ -1205,7 +1199,7 @@
                                         </div>
                                         <div class="media-body">
                                             <h4 class="media-heading">Apple</h4>
-                                            <p>Wraz z rozwojem aplikacji mobilnych do naszej firmy wkroczyły urządzenia firmy Apple od MacBookow pro i air, poprzez Macbooki mini stosowane jako serwery, po urządzenia mobilne iPhone i iPad.</p>
+                                            <p>Wraz z rozwojem aplikacji mobilnych do naszej firmy wkroczyły urządzenia firmy Apple od MacBook-ów Pro i Air, poprzez Macbooki Mini stosowane jako serwery, po urządzenia mobilne iPhone i iPad.</p>
                                         </div>
                                     </div>
 
@@ -1216,7 +1210,7 @@
                                         <div class="media-body">
                                             <h4 class="media-heading">Serwerownia</h4>
                                             <p>
-                                                W gdańskim biurze mamy własną małą serwerownię zbudowaną w 100% na najnowszych rozwiązaniach serwerowych firmy Dell. Własna serwerownia hostuje kilkaset maszyn wirtualnych &#8222;on premises&#8221;, niezbędnych w procesie wytwarzania
+                                                W gdańskim biurze mamy własną serwerownię zbudowaną w 100% na najnowszych rozwiązaniach serwerowych firmy Dell. Hostujemy tam kilkaset maszyn wirtualnych &#8222;on premises&#8221;, niezbędnych w procesie wytwarzania
                                                 naszych systemów
                                             </p>
                                         </div>


### PR DESCRIPTION
- Removed line about VCS, since almost everyone use Git, there is no point in saying "we're like any other company".
- "biblioteczka papierowych.." sounds a little too funny, I've made it more brief
- Removed duplicated info about IHS Tech Conf
- Removed list of cryptic conferences names. It looks like bad from reader perspective if he does not recognize any of these titles.
- Removed “Pakiety” since it rhymes with "rakiety" and means nothing. I consider removing the name "Infragistics" too, since I don't feel like it is something to be proud of.
- There is no Atlassian Stash anymore
- Reordered and updated list of "Czego jeszcze się nauczysz":
  - Charles does not fit here. I used it and remember its interface is trivial.
  - Nobody will learn anything useful about Ruby in Connect. Any other projects are based on Ruby?
  - Same with MSDeploy.. It is buried under pile of Rakes and Powershell scripts. After few years I haven't seem single use of MSDeploy command.
  - JSLint.. totally outdated. We use ESLint and/or TSLint now.

Please tell me if you want something back, I don't know every project and I based mostly on what I think about other projects than Connect.

Additional question:

- Does anyone really use BitBucket? I thought we all use TFS for hosting Git repos.